### PR TITLE
change `prefix` behaviour

### DIFF
--- a/R/Metalonda.R
+++ b/R/Metalonda.R
@@ -45,6 +45,8 @@ metalonda = function(Count, Time, Group, ID, n.perm = 500, fit.method = "nbinomi
                       adjust.method = "BH", time.unit = "days", ylabel = "Normalized Count", col = c("blue", "firebrick"),
                      prefix = "Test")
 {
+  cat("Start MetaLonDA \n")
+  
   if (!dir.exists(prefix)){
     dir.create(file.path(prefix))
   }

--- a/R/Metalonda.R
+++ b/R/Metalonda.R
@@ -114,8 +114,8 @@ metalonda = function(Count, Time, Group, ID, n.perm = 500, fit.method = "nbinomi
   }
   
   ## Visualize feature's trajectories spline
-  visualizeFeatureSpline(aggregate.df, model, fit.method, text, group.levels, unit = time.unit, ylabel = ylabel, 
-                         col = col, prefix = prefix)
+  #visualizeFeatureSpline(aggregate.df, model, fit.method, text, group.levels, unit = time.unit, ylabel = ylabel, 
+  #                       col = col, prefix = prefix)
  
    
   ## Calculate area under the fitted curve for each time interval
@@ -192,13 +192,13 @@ metalonda = function(Count, Time, Group, ID, n.perm = 500, fit.method = "nbinomi
   ## Output table summarizing time intervals statistics
   output.details$points = output.details$points[-length(output.details$points)]
   feature.summary = as.data.frame(do.call(cbind, output.details), stringsAsFactors = FALSE)
-  write.csv(feature.summary, file = sprintf("%s/Feature_%s_Summary.csv", prefix, text), row.names = FALSE)
+  #write.csv(feature.summary, file = sprintf("%s/Feature_%s_Summary.csv", prefix, text), row.names = FALSE)
   
   
   aggregateData = list(feature.detail = output.details, feature.summary = feature.summary, feature.model = model)
-  save(aggregateData, 
-       file = sprintf("%s/Feature_%s_Summary_%s.RData",
-                      prefix, text, fit.method))
+  #save(aggregateData, 
+  #     file = sprintf("%s/Feature_%s_Summary_%s.RData",
+  #                    prefix, text, fit.method))
   cat("\n\n")
   
   

--- a/R/Metalonda.R
+++ b/R/Metalonda.R
@@ -84,7 +84,7 @@ metalonda = function(Count, Time, Group, ID, n.perm = 500, fit.method = "nbinomi
 
 
   ## Visualize feature's abundance accross different time points  
-  visualizeFeature(aggregate.df, text, group.levels, unit = time.unit, ylabel = ylabel, col = col, prefix = prefix)
+  #visualizeFeature(aggregate.df, text, group.levels, unit = time.unit, ylabel = ylabel, col = col, prefix = prefix)
 
   
   group.0 = aggregate.df[aggregate.df$Group == 0, ]

--- a/R/Metalonda.R
+++ b/R/Metalonda.R
@@ -46,6 +46,7 @@ metalonda = function(Count, Time, Group, ID, n.perm = 500, fit.method = "nbinomi
                      prefix = "Test")
 {
   cat("Start MetaLonDA \n")
+  
   if (!dir.exists(prefix)){
     dir.create(file.path(prefix))
   }

--- a/R/Metalonda.R
+++ b/R/Metalonda.R
@@ -46,7 +46,6 @@ metalonda = function(Count, Time, Group, ID, n.perm = 500, fit.method = "nbinomi
                      prefix = "Test")
 {
   cat("Start MetaLonDA \n")
-  
   if (!dir.exists(prefix)){
     dir.create(file.path(prefix))
   }

--- a/R/Metalonda.R
+++ b/R/Metalonda.R
@@ -317,6 +317,9 @@ metalondaAll = function(Count, Time, Group, ID, n.perm = 500,
   detailed = list()
   summary = list()
   model = list()
+  cat("STEFAN: num featurs:")
+  cat(n.features)
+  cat("\n")
   for (i in 1:n.features)
   {
     cat ("Feature  = ", rownames(data.count.filt)[i], "\n")

--- a/R/Metalonda.R
+++ b/R/Metalonda.R
@@ -313,7 +313,7 @@ metalondaAll = function(Count, Time, Group, ID, n.perm = 500,
   data.count.filt = as.matrix(Count)
   
   ## Apply metalonda for each feature
-  n.features = nrow(data.count.filt)
+  n.features = 3 #nrow(data.count.filt)
   detailed = list()
   summary = list()
   model = list()

--- a/R/Metalonda.R
+++ b/R/Metalonda.R
@@ -339,10 +339,10 @@ metalondaAll = function(Count, Time, Group, ID, n.perm = 500,
   summary.tmp$dominant[which(summary.tmp$dominant == -1)] = gr.2
   
   ## Output table and figure that summarize the significant time intervals
-  write.csv(summary.tmp, file = sprintf("%s/%s_MetaLonDA_TimeIntervals.csv", prefix, prefix), row.names = FALSE)
+  write.csv(summary.tmp, file = sprintf("%s/MetaLonDA_TimeIntervals.csv", prefix), row.names = FALSE)
   visualizeTimeIntervals(interval.details = summary.tmp, prefix, unit = time.unit, col = col)
   
   aggregateData = list(output.detail = detailed, output.summary = summary.tmp, output.model = model)
-  save(aggregateData, file = sprintf("%s/%s_MetaLonDA.RData", prefix, prefix))
+  save(aggregateData, file = sprintf("%s/MetaLonDA.RData", prefix))
   return(aggregateData)
 }

--- a/R/Metalonda.R
+++ b/R/Metalonda.R
@@ -46,6 +46,9 @@ metalonda = function(Count, Time, Group, ID, n.perm = 500, fit.method = "nbinomi
                      prefix = "Test")
 {
   cat("Start MetaLonDA \n")
+  cat("STEFAN, open connections: ")
+  cat(nrow(showConnections()))
+  cat("\n")
 
   if (!dir.exists(prefix)){
     dir.create(file.path(prefix))

--- a/R/Metalonda.R
+++ b/R/Metalonda.R
@@ -45,11 +45,6 @@ metalonda = function(Count, Time, Group, ID, n.perm = 500, fit.method = "nbinomi
                       adjust.method = "BH", time.unit = "days", ylabel = "Normalized Count", col = c("blue", "firebrick"),
                      prefix = "Test")
 {
-  cat("Start MetaLonDA \n")
-  cat("STEFAN, open connections: ")
-  cat(nrow(showConnections()))
-  cat("\n")
-
   if (!dir.exists(prefix)){
     dir.create(file.path(prefix))
   }
@@ -84,7 +79,7 @@ metalonda = function(Count, Time, Group, ID, n.perm = 500, fit.method = "nbinomi
 
 
   ## Visualize feature's abundance accross different time points  
-  #visualizeFeature(aggregate.df, text, group.levels, unit = time.unit, ylabel = ylabel, col = col, prefix = prefix)
+  visualizeFeature(aggregate.df, text, group.levels, unit = time.unit, ylabel = ylabel, col = col, prefix = prefix)
 
   
   group.0 = aggregate.df[aggregate.df$Group == 0, ]
@@ -114,8 +109,8 @@ metalonda = function(Count, Time, Group, ID, n.perm = 500, fit.method = "nbinomi
   }
   
   ## Visualize feature's trajectories spline
-  #visualizeFeatureSpline(aggregate.df, model, fit.method, text, group.levels, unit = time.unit, ylabel = ylabel, 
-  #                       col = col, prefix = prefix)
+  visualizeFeatureSpline(aggregate.df, model, fit.method, text, group.levels, unit = time.unit, ylabel = ylabel, 
+                         col = col, prefix = prefix)
  
    
   ## Calculate area under the fitted curve for each time interval
@@ -192,13 +187,13 @@ metalonda = function(Count, Time, Group, ID, n.perm = 500, fit.method = "nbinomi
   ## Output table summarizing time intervals statistics
   output.details$points = output.details$points[-length(output.details$points)]
   feature.summary = as.data.frame(do.call(cbind, output.details), stringsAsFactors = FALSE)
-  #write.csv(feature.summary, file = sprintf("%s/Feature_%s_Summary.csv", prefix, text), row.names = FALSE)
+  write.csv(feature.summary, file = sprintf("%s/Feature_%s_Summary.csv", prefix, text), row.names = FALSE)
   
   
   aggregateData = list(feature.detail = output.details, feature.summary = feature.summary, feature.model = model)
-  #save(aggregateData, 
-  #     file = sprintf("%s/Feature_%s_Summary_%s.RData",
-  #                    prefix, text, fit.method))
+  save(aggregateData, 
+       file = sprintf("%s/Feature_%s_Summary_%s.RData",
+                      prefix, text, fit.method))
   cat("\n\n")
   
   
@@ -313,13 +308,10 @@ metalondaAll = function(Count, Time, Group, ID, n.perm = 500,
   data.count.filt = as.matrix(Count)
   
   ## Apply metalonda for each feature
-  n.features = 3 #nrow(data.count.filt)
+  n.features = nrow(data.count.filt)
   detailed = list()
   summary = list()
   model = list()
-  cat("STEFAN: num featurs:")
-  cat(n.features)
-  cat("\n")
   for (i in 1:n.features)
   {
     cat ("Feature  = ", rownames(data.count.filt)[i], "\n")

--- a/R/Visualization.R
+++ b/R/Visualization.R
@@ -214,7 +214,7 @@ visualizeTimeIntervals = function(interval.details, prefix = "Test", unit = "day
           panel.grid.major.y = element_line(colour = "white", size = 6),
           panel.grid.major.x = element_line(colour = "white",size = 0.75)) +
     theme(legend.position="top", panel.border = element_rect(colour = "black", fill = NA, size = 2))
-  ggsave(filename = paste(prefix, "/", prefix, "_MetaLonDA_TimeIntervals.jpg", sep=""), dpi = 1200, height = 30, width = 20, units = 'cm')
+  ggsave(filename = paste(prefix, "/MetaLonDA_TimeIntervals.jpg", sep=""), dpi = 1200, height = 30, width = 20, units = 'cm')
 }
 
 


### PR DESCRIPTION
This is addressing #8 
My problem was that I misunderstood the meaning of the `prefix` parameter. Documentation says `prefix for the output figure`. Coming from gcc compilations, I gave an absolute path as the prefix. But I figure it is intended to be "just" a name.
Hence, the double concatenation of `prefix` in e.g. https://github.com/aametwally/MetaLonDA/blob/2ad94285d2a4cc7ca6af749f3539db37b4f1d35e/R/Metalonda.R#L336 results in an impossible or at least non existent file path.

With this #PR, I'd like to suggest to slightly change the meaning of `prefix` into a file path.